### PR TITLE
fix: fix patch and reorder render

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -89,10 +89,10 @@ export default definePlugin({
         },
         { // New panel patch
             predicate: () => settings.store.showPanel,
-            find: "this.renderEmbeddedActivity()",
+            find: "this.renderVoicePanelIntroduction",
             replacement: {
-                match: /(?<=let{canGoLive.{0,1500}\()"div"(?=,{className:\i(?:\.body|\(\)\())/,
-                replace: "$self.WrapperComponent"
+                match: /(let{(?:channel:\i,)?canGoLive.{0,1500}\()"div"(?=,{(?:ref:this\.ref,)?className:\i(?:\.body|\(\)\(|\.\i))/,
+                replace: "$1$self.WrapperComponent"
             }
         }
     ],
@@ -123,7 +123,6 @@ export default definePlugin({
 
         return (
             <>
-                <div {...props}>{props.children}</div>
                 <div className={classes(cl("spectators_panel"), ActivityPanelStyles.activityPanel)}>
                     {users.length ?
                         <>
@@ -155,6 +154,7 @@ export default definePlugin({
                         : <Paragraph>No spectators</Paragraph>
                     }
                 </div>
+                <div {...props}>{props.children}</div>
             </>
         );
     }),


### PR DESCRIPTION
I tried to make it retro-compatible because that's a common practice in Vencord's official code. The regex patch should be retro-compatible. Nevertheless, changing the position of `<div {...props}>{props.children}</div>` probably will make the panel be rendered below the voice chat buttons for users who have an old version of Discord.

If you don't care about the retro-compatibility, here's a shorter patch:

```ts
        { // New panel patch
            predicate: () => settings.store.showPanel,
            find: "this.renderVoicePanelIntroduction",
            replacement: {
                match: /(?<=Animation\.TRANSLATE.{0,50}\()"div"(?=,{ref:this\.ref)/,
                replace: "$self.WrapperComponent"
            }
        }
```